### PR TITLE
Adding support setting multiple cookies in header

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,9 @@ function cookiePlugin() {
                     actionContext.setCookie = function (name, value, options) {
                         var cookieStr = cookie.serialize(name, value, options);
                         if (res) {
-                            res.setHeader('Set-Cookie', cookieStr);
+                            var pendingCookiesArray = res.getHeader('Set-Cookie') || [];
+                            var newCookiesArray = pendingCookiesArray.concat(cookieStr);
+                            res.setHeader('Set-Cookie', newCookiesArray);
                         } else {
                             document.cookie = cookieStr;
                         }

--- a/index.js
+++ b/index.js
@@ -11,23 +11,28 @@ function cookiePlugin() {
 
             var cookies = req ? req.cookies : cookie.parse(document.cookie);
 
-            return {
-                plugActionContext: function (actionContext) {
-                    actionContext.setCookie = function (name, value, options) {
-                        var cookieStr = cookie.serialize(name, value, options);
-                        if (res) {
-                            var pendingCookiesArray = res.getHeader('Set-Cookie') || [];
-                            var newCookiesArray = pendingCookiesArray.concat(cookieStr);
-                            res.setHeader('Set-Cookie', newCookiesArray);
-                        } else {
-                            document.cookie = cookieStr;
-                        }
-                        cookies[name] = value;
-                    };
-                    actionContext.getCookie = function (name) {
-                        return cookies[name];
+            // same plugin for action and store contexts.
+            // give them both access to cookies
+            var contextPlug = function (context) {
+                context.setCookie = function (name, value, options) {
+                    var cookieStr = cookie.serialize(name, value, options);
+                    if (res) {
+                        var pendingCookiesArray = res.getHeader('Set-Cookie') || [];
+                        var newCookiesArray = pendingCookiesArray.concat(cookieStr);
+                        res.setHeader('Set-Cookie', newCookiesArray);
+                    } else {
+                        document.cookie = cookieStr;
                     }
+                    cookies[name] = value;
+                };
+                context.getCookie = function (name) {
+                    return cookies[name];
                 }
+            }
+
+            return {
+                plugActionContext: contextPlug,
+                plugStoreContext: contextPlug
             };
         }
     };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Antoine Hérault <antoine.herault@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "cookie": "git://github.com/Hairfie/cookie#master"
+    "cookie": "0.3.1",
+    "utils-merge": "1.0.0"
   }
 }


### PR DESCRIPTION
Node supports setting multiple cookies with a single header:
https://nodejs.org/api/http.html#http_response_setheader_name_value

This PR adds that functionality to this plugin.

Summary of changes:
- Check what is currently awaiting in the header, default an empty array
- Add the new cookie string to the array via concat
- Set as the new value
